### PR TITLE
Disable some UIKit features

### DIFF
--- a/Projects/Xcode-iOS/Resources/Info.plist
+++ b/Projects/Xcode-iOS/Resources/Info.plist
@@ -28,6 +28,8 @@
 	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>

--- a/Projects/Xcode-iOS/Resources/Info.plist
+++ b/Projects/Xcode-iOS/Resources/Info.plist
@@ -26,16 +26,10 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
Tiny PR that hides the status bar on the launch screen, disables portrait orientations and requires fullscreen, which makes it ineligible for Slide Over and Split View. None of these features work well here.

Tested on my iPhone and an iPad simulator.